### PR TITLE
Remove leading slash for detail.php URLs from php/newsfeed_trendip.php

### DIFF
--- a/php/newsfeed_trendip.php
+++ b/php/newsfeed_trendip.php
@@ -112,7 +112,7 @@ if($glb_debug==1){
 	
 			$categorybits=preg_split('/\|/', $k);
 	
-			echo "<a href='/detail.php?from=".$prevdate."&category=".$categorybits[0]."&ipmatch=".$key."'>".$categorybits[1]."</a> (".number_format($v)."), ";
+			echo "<a href='detail.php?from=".$prevdate."&category=".$categorybits[0]."&ipmatch=".$key."'>".$categorybits[1]."</a> (".number_format($v)."), ";
 	
 		}
 	


### PR DESCRIPTION
I've removed the leading slash from the line containing detail.php, as this causes the generated anchor link to be incorrect when the analogi directory is not the root of the web server.
